### PR TITLE
Checkbox [fix]: prevent default onkeypress action

### DIFF
--- a/src/components/Input/Checkbox.js
+++ b/src/components/Input/Checkbox.js
@@ -35,7 +35,10 @@ class Checkbox extends React.PureComponent {
     if (checked) return 'true'
     return 'false'
   }
-  handleClick = () => {
+  handleKeyPress = e => {
+    e.preventDefault()
+  }
+  handleClick = e => {
     const { onChange, checked, indeterminate } = this.props
     onChange(indeterminate ? false : !checked)
   }
@@ -95,6 +98,7 @@ class Checkbox extends React.PureComponent {
             tabIndex={tabIndex}
             aria-checked={this.getAriaChecked()}
             onClick={this.handleClick}
+            onKeyPress={this.handleKeyPress}
             onFocus={onFocus}
             disabled={disabled}
             css={`


### PR DESCRIPTION
### Description

Given that the `<Checkbox/>` component renders a `<span>` element with a `<button>` element as a parent, by default, the `Enter` key triggers the `keypress` event. 

This PR disables the default action on the `keypress` event that triggers the `click` event later on.

**Note**: the checkbox can still be checked with the `Space` key thanks to the `role` attribute.

Resolves #626 