### PR TITLE
Feature/dao 370 aragon UI CI workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,26 +20,31 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ env.NODE_VERSION }}
-    - name: Install, build & test
+    - name: Install, build
       run: |
         yarn install --frozen-lockfile
         yarn build
-        yarn test
+    - name: Cache build
+      uses: actions/cache@v2
+      with:
+        path: ./*
+        key: ${{ github.sha }}
+    - name: Test
+      run: yarn test
 
   release:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v1
     - name: Use Node.js ${{ env.NODE_VERSION }}
       uses: actions/setup-node@v1
       with:
         node-version: ${{ env.NODE_VERSION }}
-    - name: Install, build & test
-      run: |
-        yarn install --frozen-lockfile
-        yarn build
+    - name: Restore cache
+      uses: actions/cache@v2
+      with:
+        path: ./*
+        key: ${{ github.sha }}
     - name: Release
       env:
         GITHUB_TOKEN: ${{ secrets.MERGE_RELEASE_GITHUB_TOKEN }}
@@ -50,16 +55,15 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v1
     - name: Use Node.js ${{ env.NODE_VERSION }}
       uses: actions/setup-node@v1
       with:
         node-version: ${{ env.NODE_VERSION }}
-    - name: Install, build & test
-      run: |
-        yarn install --frozen-lockfile
-        yarn build
+    - name: Restore build cache
+      uses: actions/cache@v2
+      with:
+        path: ./*
+        key: ${{ github.sha }}
     - name: Install, build & prepare
       run: |
         cd gallery
@@ -68,8 +72,7 @@ jobs:
         echo 'ui.aragon.org' > dist/CNAME
         cp public/favicon.svg dist
     - name: Push to gh-pages
-      env:
-        ACTIONS_DEPLOY_KEY: ${{ secrets.GH_PAGES_ACTIONS_DEPLOY_KEY }}
-        PUBLISH_BRANCH: gh-pages
-        PUBLISH_DIR: ./gallery/dist
-      uses: peaceiris/actions-gh-pages@v2
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./gallery/dist

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [master]
 
+env:
+  NODE_VERSION: 12.x
+
 jobs:
 
   build:
@@ -13,10 +16,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v1
-    - name: Use Node.js 12
+    - name: Use Node.js ${{ env.NODE_VERSION }}
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: ${{ env.NODE_VERSION }}
     - name: Install, build & test
       run: |
         yarn install --frozen-lockfile
@@ -27,6 +30,16 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Use Node.js ${{ env.NODE_VERSION }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+    - name: Install, build & test
+      run: |
+        yarn install --frozen-lockfile
+        yarn build
     - name: Release
       env:
         GITHUB_TOKEN: ${{ secrets.MERGE_RELEASE_GITHUB_TOKEN }}
@@ -37,6 +50,16 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Use Node.js ${{ env.NODE_VERSION }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+    - name: Install, build & test
+      run: |
+        yarn install --frozen-lockfile
+        yarn build
     - name: Install, build & prepare
       run: |
         cd gallery

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ name: Build and publish
 on:
   push:
     branches: [master]
+    tags:
+      - 'v*.*.*'
 
 env:
   NODE_VERSION: 12.x
@@ -15,12 +17,12 @@ jobs:
       CI: true
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Use Node.js ${{ env.NODE_VERSION }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ env.NODE_VERSION }}
-    - name: Install, build
+    - name: Install, build, Test
       run: |
         yarn install --frozen-lockfile
         yarn build
@@ -34,29 +36,46 @@ jobs:
 
   release:
     needs: [build]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Release
+      uses: marvinpinto/action-automatic-releases@v1.2.1
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        prerelease: false
+
+  publish:
+    needs: [release]
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
     - name: Use Node.js ${{ env.NODE_VERSION }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ env.NODE_VERSION }}
-    - name: Restore cache
+        registry-url: 'https://registry.npmjs.org'
+    - name: Restore build cache
       uses: actions/cache@v2
       with:
         path: ./*
         key: ${{ github.sha }}
-    - name: Release
+    - name: Publish
       env:
-        GITHUB_TOKEN: ${{ secrets.MERGE_RELEASE_GITHUB_TOKEN }}
-        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-      uses: mikeal/merge-release@master
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+      run: npm publish
 
   deploy-website:
-    needs: [build]
+    needs: [publish]
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
     - name: Use Node.js ${{ env.NODE_VERSION }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ env.NODE_VERSION }}
     - name: Restore build cache
@@ -64,13 +83,19 @@ jobs:
       with:
         path: ./*
         key: ${{ github.sha }}
-    - name: Install, build & prepare
+    - name: Install, build & prepare gallery
       run: |
         cd gallery
         yarn --frozen-lockfile
         yarn build
         echo 'ui.aragon.org' > dist/CNAME
         cp public/favicon.svg dist
+    - name: Install, build & prepare devbox
+      run: |
+        cd devbox
+        yarn --frozen-lockfile
+        yarn build
+        cp -rf dist ../gallery/dist/devbox
     - name: Push to gh-pages
       uses: peaceiris/actions-gh-pages@v3
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,12 +90,6 @@ jobs:
         yarn build
         echo 'ui.aragon.org' > dist/CNAME
         cp public/favicon.svg dist
-    - name: Install, build & prepare devbox
-      run: |
-        cd devbox
-        yarn --frozen-lockfile
-        yarn build
-        cp -rf dist ../gallery/dist/devbox
     - name: Push to gh-pages
       uses: peaceiris/actions-gh-pages@v3
       with:

--- a/README.md
+++ b/README.md
@@ -85,6 +85,18 @@ See `copy-aragon-ui-assets -h` for more information.
 
 Please have a look at [CONTRIBUTING.md](CONTRIBUTING.md).
 
+## Release and Publish to npm
+
+Git checkout from master branch and make sure no local changes and run the following commands to make a release and publish to npm
+
+```sh
+# release a patch
+npm run release:patch
+# make a minor release
+npm run release:minor
+# make a major release (with breaking changes)
+npm run release:major
+```
 ## Projects using aragonUI
 
 - [Aragon client](https://github.com/aragon/aragon) and [core apps](https://github.com/aragon/aragon-apps)

--- a/package.json
+++ b/package.json
@@ -30,7 +30,10 @@
     "lint:fix": "eslint --fix ./src",
     "optimize:svg": "find ./src/components -name *.svg -exec svgo --config '{ \"plugins\": [ { \"removeDesc\": {\"removeAny\": true} }, { \"removeTitle\": true }, { \"removeViewBox\": false } ] }' {} \\;",
     "prepare": "rm -rf ./dist && npm run build",
-    "prepublishOnly": "git push && git push --tags",
+    "push:tag": "git push && git push --tags",
+    "release:patch": "npm version patch && npm run push:tag",
+    "release:minor": "npm version minor && npm run push:tag",
+    "release:major": "npm version major && npm run push:tag",
     "start": "cd gallery && npm start",
     "test": "npm run lint && npm run jest"
   },


### PR DESCRIPTION
@novaknole  can you please revisit this PR which fixes the broken build/release flow for Aragon UI?  May be check with Mathias to see if this is the flow is ok?

Steps to publish the aragon/ui to npm and build the aragon ui doc proposed by this PR:
1) checkout the code
2) run `npm version major|minor|patch` to bump the version
3) push the change triggering the CI job to make a github release, publish to npm and update the UI doc which is hosted on github pages.

Also, not sure what we want to do with the deployment of devbox (for previewing all UI components)..


